### PR TITLE
Bring over latest changes from the Plugin Deploy Action

### DIFF
--- a/build-zip.sh
+++ b/build-zip.sh
@@ -51,6 +51,11 @@ if [[ "$BUILD_DIR" = false ]]; then
 		TMP_DIR="${HOME}/archivetmp"
 		mkdir "$TMP_DIR"
 
+		# Workaround for: detected dubious ownership in repository at '/github/workspace' issue.
+		# See: https://github.com/10up/action-wordpress-plugin-deploy/issues/116
+		# Mark github workspace as safe directory.
+		git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 		git config --global user.email "10upbot+github@10up.com"
 		git config --global user.name "10upbot on GitHub"
 

--- a/build-zip.sh
+++ b/build-zip.sh
@@ -59,6 +59,14 @@ if [[ "$BUILD_DIR" = false ]]; then
 		git config --global user.email "10upbot+github@10up.com"
 		git config --global user.name "10upbot on GitHub"
 
+		# Ensure git archive will pick up any changed files in the directory.
+		# See https://github.com/10up/action-wordpress-plugin-deploy/pull/130
+		test $(git ls-files --deleted) && git rm $(git ls-files --deleted)
+		if [ -n "$(git status --porcelain --untracked-files=all)" ]; then
+			git add .
+			git commit -m "Include build step changes"
+		fi
+
 		# If there's no .gitattributes file, write a default one into place
 		if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
 			cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL


### PR DESCRIPTION
### Description of the Change

This Action was copied from our [Plugin Deploy Action](https://github.com/10up/action-wordpress-plugin-deploy), with any non-relevant pieces removed. There have been a number of changes to that Action since so this PR brings over the couple that are relevant:

1. Handle dubious ownership error: https://github.com/10up/action-wordpress-plugin-deploy/pull/119
2. Ensure changed files are added properly to release: https://github.com/10up/action-wordpress-plugin-deploy/pull/130

### How to test the Change

Ensure the Action still works as expected

### Changelog Entry

> Fixed - Handle the error `detected dubious ownership in repository at '/github/workspace'` when using a `.gitattributes` file.
> Fixed - Ensure built files are included when used without a `BUILD_DIR` and `.distignore` file.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
