### PR TITLE
Install `svn` if needed

### DIFF
--- a/build-zip.sh
+++ b/build-zip.sh
@@ -6,6 +6,32 @@
 # it does not exit with a 0, and we only care about the final exit.
 set -eo
 
+# Function to check if a command exists
+command_exists() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+# Check if SVN is installed
+if command_exists svn; then
+	echo "SVN is already installed."
+else
+	echo "SVN is not installed. Installing SVN..."
+
+	# Update the package list
+	sudo apt-get update -y
+
+	# Install SVN
+	sudo apt-get install -y subversion
+
+	# Verify installation
+	if command_exists svn; then
+		echo "SVN was successfully installed."
+	else
+		echo "Failed to install SVN. Please check your system configuration."
+		exit 1
+	fi
+fi
+
 # Allow some ENV variables to be customized
 if [[ -z "$SLUG" ]]; then
 	SLUG=${GITHUB_REPOSITORY#*/}

--- a/build-zip.sh
+++ b/build-zip.sh
@@ -87,7 +87,7 @@ if [[ "$BUILD_DIR" = false ]]; then
 
 		# Ensure git archive will pick up any changed files in the directory.
 		# See https://github.com/10up/action-wordpress-plugin-deploy/pull/130
-		test $(git ls-files --deleted) && git rm $(git ls-files --deleted)
+		test "$(git ls-files --deleted)" && git rm "$(git ls-files --deleted)"
 		if [ -n "$(git status --porcelain --untracked-files=all)" ]; then
 			git add .
 			git commit -m "Include build step changes"


### PR DESCRIPTION
### Description of the Change

SVN is no longer installed by default in GitHub Actions. This means anyone using this action either has to install SVN themselves or things will start to fail. This PR addresses that by checking if SVN is installed and if not, it will then install it itself.

This is based off the work done in our other Actions: https://github.com/10up/action-wordpress-plugin-deploy/pull/160 and https://github.com/10up/action-wordpress-plugin-asset-update/pull/62

### How to test the Change

Ensure the action still works as expected, especially in environments that don't have svn installed

### Changelog Entry

> Fixed - Install SVN as part of the workflow

### Credits

Props @dkotter, @kirtangajjar

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
